### PR TITLE
Add string representations for pieces and board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bin/
 obj/
 *.DotSettings.user
+.editorconfig

--- a/Chess/Board.cs
+++ b/Chess/Board.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace Chess;
 
@@ -14,6 +15,26 @@ public class Board
         // TODO validate given pieces - they could be in invalid positions
         _pieces = board.ToArray();
         _lastMove = lastMove;
+    }
+
+    public override string ToString()
+    {
+        var boardMatrix = new Piece?[8, 8];
+        foreach (var piece in _pieces)
+        {
+            boardMatrix[piece.Position.X, piece.Position.Y] = piece;
+        }
+
+        var stringRepresentation = new StringBuilder();
+        for (int x = 0; x < 8; x++)
+        {
+            for (int y = 0; y < 8; y++)
+                stringRepresentation.Append(boardMatrix[x, y]?.ToString() ?? "\u00B7");
+
+            stringRepresentation.Append('\n');
+        }
+
+        return stringRepresentation.ToString();
     }
 
     public bool HasInsufficientMatingMaterial()
@@ -47,7 +68,7 @@ public class Board
         {
             return true;
         }
-        
+
         return false;
     }
 
@@ -109,7 +130,7 @@ public class Board
         return _pieces
             .ToArray();
     }
-    
+
     public List<Move> GetAllPossibleMovesForColor(Color color)
     {
         var pieces = GetPieces(color);
@@ -160,7 +181,7 @@ public class Board
             .First(k => k.Type == PieceType.King && k.Color == color);
         return IsFieldUnderAttack(king.Position, king.Color.GetOppositeColor());
     }
-    
+
     /// <summary>
     /// Check if given field is under attack by given color's pieces
     /// </summary>
@@ -185,7 +206,7 @@ public class Board
             .Where(p => p.Color == color)
             .ToArray();
     }
-    
+
     /// <summary>
     /// Get moves for the piece without taking into consideration all the rules
     /// But then we should put the logic somewhere to detect that we can't jump over other pieces.

--- a/Chess/Piece.cs
+++ b/Chess/Piece.cs
@@ -1,23 +1,45 @@
+using System;
+
 namespace Chess;
 
 public record Piece
 {
-	public Piece(PieceType type, Color color, Vector position, bool moved = false)
-	{
-		Type = type;
-		Color = color;
-		Position = position;
-		Moved = moved;
-	}
+    public Piece(PieceType type, Color color, Vector position, bool moved = false)
+    {
+        Type = type;
+        Color = color;
+        Position = position;
+        Moved = moved;
+    }
 
-	public bool Moved { get; }
-	public Vector Position { get; }
-	public Color Color { get; }
-	public PieceType Type { get; }
+    public bool Moved { get; }
+    public Vector Position { get; }
+    public Color Color { get; }
+    public PieceType Type { get; }
 
-	public Piece Move(Vector position)
-	{
-		var clonedPiece = new Piece(this.Type, this.Color, position, true);
-		return clonedPiece;
-	}
+    public Piece Move(Vector position)
+    {
+        var clonedPiece = new Piece(this.Type, this.Color, position, true);
+        return clonedPiece;
+    }
+
+    public override string ToString()
+    {
+        return (Type, Color) switch
+        {
+            (PieceType.King, Color.WHITE) => "\u2654",
+            (PieceType.King, Color.BLACK) => "\u265a",
+            (PieceType.Queen, Color.WHITE) => "\u2655",
+            (PieceType.Queen, Color.BLACK) => "\u265b",
+            (PieceType.Rock, Color.WHITE) => "\u2656",
+            (PieceType.Rock, Color.BLACK) => "\u265c",
+            (PieceType.Bishop, Color.WHITE) => "\u2657",
+            (PieceType.Bishop, Color.BLACK) => "\u265d",
+            (PieceType.Knight, Color.WHITE) => "\u2658",
+            (PieceType.Knight, Color.BLACK) => "\u265e",
+            (PieceType.Pawn, Color.WHITE) => "\u2659",
+            (PieceType.Pawn, Color.BLACK) => "\u265f",
+            _ => throw new ArgumentOutOfRangeException(),
+        };
+    }
 }


### PR DESCRIPTION
Use the unicode characters representing chess pieces to create a simple ToString method for the board. This allows us to print the board, which is helpful for debugging :)

Source: https://en.wikipedia.org/wiki/Chess_symbols_in_Unicode

Hope you are having a great weekend!