### PR TITLE
Only consider checks from the perspective of the king

### DIFF
--- a/Chess/Bishop.cs
+++ b/Chess/Bishop.cs
@@ -4,7 +4,7 @@ namespace Chess;
 
 internal static class Bishop
 {
-    public static ICollection<Move> GetBishopMoves(Piece piece, Piece[,] board)
+    public static List<Move> GetBishopMoves(Piece piece, Piece[,] board)
     {
         var moves = new List<Move>();
         moves.AddRange(board.GetMovesInDirection(piece, Vector.Up + Vector.Right,   piece.Color));

--- a/Chess/Board.cs
+++ b/Chess/Board.cs
@@ -269,15 +269,14 @@ public class Board
     /// <returns></returns>
     private bool IsFieldUnderAttack(Vector field, Color color)
     {
-        var pieces = GetPieces(color);
-        foreach (var piece in pieces)
+        foreach (PieceType pieceType in Enum.GetValues(typeof(PieceType)))
         {
-            var possibleMoves = GetMoves(piece);
-            if (possibleMoves.Any(m => m.PieceNewPosition == field))
-            {
+            var pretendPiece = new Piece(pieceType, color.GetOppositeColor(), field);
+            var moves = GetMoves(pretendPiece).ToList();
+            if (moves.Exists(m => m is Capture capture && capture.CapturedPiece.Type == pieceType))
                 return true;
-            }
         }
+
         return false;
     }
 

--- a/Chess/Board.cs
+++ b/Chess/Board.cs
@@ -269,10 +269,11 @@ public class Board
     /// <returns></returns>
     private bool IsFieldUnderAttack(Vector field, Color color)
     {
+        var oppositeColor = color.GetOppositeColor();
         foreach (PieceType pieceType in Enum.GetValues(typeof(PieceType)))
         {
-            var pretendPiece = new Piece(pieceType, color.GetOppositeColor(), field);
-            var moves = GetMoves(pretendPiece).ToList();
+            var pretendPiece = new Piece(pieceType, oppositeColor, field);
+            var moves = GetMoves(pretendPiece);
             if (moves.Exists(m => m is Capture capture && capture.CapturedPiece.Type == pieceType))
                 return true;
         }
@@ -293,7 +294,7 @@ public class Board
     /// </summary>
     /// <param name="piece"></param>
     /// <returns></returns>
-    private ICollection<Move> GetMoves(Piece piece)
+    private List<Move> GetMoves(Piece piece)
     {
         var moves = piece.Type switch
         {

--- a/Chess/Pawn.cs
+++ b/Chess/Pawn.cs
@@ -4,7 +4,7 @@ namespace Chess;
 
 internal static class Pawn
 {
-    public static ICollection<Move> GetPawnMoves(Piece piece, Piece[,] board, Move? lastMove)
+    public static List<Move> GetPawnMoves(Piece piece, Piece[,] board, Move? lastMove)
     {
         var moves = new List<Move>();
         var direction = piece.Color == Color.WHITE ? Vector.Up : Vector.Down;

--- a/Chess/Pawn.cs
+++ b/Chess/Pawn.cs
@@ -11,9 +11,7 @@ internal static class Pawn
 
         // one step forward if not blocked
         var forward = piece.Position + direction;
-        // I don't think I have to validate if forward position is within board.
-        // there is no way to get a pawn to the last rank and keep it as a pawn.
-        if (!IsBlocked(forward, board))
+        if (forward.IsWithinBoard() && !IsBlocked(forward, board))
         {
             moves.Add(new Move(piece, forward));
 
@@ -21,7 +19,7 @@ internal static class Pawn
             if (!piece.Moved)
             {
                 var forward2Steps = piece.Position + direction + direction;
-                if (!IsBlocked(forward2Steps, board))
+                if (forward2Steps.IsWithinBoard() && !IsBlocked(forward2Steps, board))
                 {
                     moves.Add(new Move(piece, forward2Steps));
                 }
@@ -79,7 +77,7 @@ internal static class Pawn
         var isThePawnNowNextToUs = (lastMove.PieceNewPosition - piece.Position) == new Vector((capturePosition - piece.Position).X, 0);
         if (isPawn && // was it a pawn
             is2StepMove && // was it a 2 step move
-            isThePawnNowNextToUs) // was it move next to us 
+            isThePawnNowNextToUs) // was it move next to us
         {
             var pieceToCapture = lastMove.PieceToMove.Move(lastMove.PieceNewPosition);
             return new Capture(piece, capturePosition, pieceToCapture);

--- a/Chess/Queen.cs
+++ b/Chess/Queen.cs
@@ -4,7 +4,7 @@ namespace Chess;
 
 public static class Queen
 {
-    public static ICollection<Move> GetQueenMoves(Piece piece, Piece[,] board)
+    public static List<Move> GetQueenMoves(Piece piece, Piece[,] board)
     {
         var moves = new List<Move>();
         moves.AddRange(board.GetMovesInDirection(piece, Vector.Up + Vector.Right,   piece.Color));

--- a/Chess/Rock.cs
+++ b/Chess/Rock.cs
@@ -4,7 +4,7 @@ namespace Chess;
 
 internal static class Rock
 {
-    public static ICollection<Move> GetRockMoves(Piece piece, Piece[,] board)
+    public static List<Move> GetRockMoves(Piece piece, Piece[,] board)
     {
         var moves = new List<Move>();
         moves.AddRange(board.GetMovesInDirection(piece, Vector.Down,  piece.Color));


### PR DESCRIPTION
A way to optimise the how checks are checked. Instead of checking for every piece if it can capture the king, we check whether a piece placed where the king is can capture a piece of the same kind from where it stands.

On my machine this brings the running time of the perft-4 test down from 4.5s to <3s.

In relation to: https://github.com/ugly-one/chess/issues/2